### PR TITLE
TMI2-322/address-critical-dependency-vulnerabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,12 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-security</artifactId>
+			<exclusions>
+				<exclusion>
+					<groupId>org.yaml</groupId>
+					<artifactId>snakeyaml</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -102,6 +108,11 @@
 			<groupId>org.hibernate.validator</groupId>
 			<artifactId>hibernate-validator</artifactId>
 			<version>8.0.1.Final</version>
+		</dependency>
+		<dependency>
+			<groupId>org.yaml</groupId>
+			<artifactId>snakeyaml</artifactId>
+			<version>2.2</version>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
- Updated snakeYAML dependency to version 2.2 which patches critical vulnerabilities.
- Excluded vulnerable snakeYAML version 1.33 from spring-boot-starter-security dependency.