### PR TITLE
Update spring boot starter parent

### DIFF
--- a/.github/workflows/feature.yml
+++ b/.github/workflows/feature.yml
@@ -39,6 +39,7 @@ jobs:
           format: "HTML"
           args: >
             --failOnCVSS 7.0
+            --suppress ./api/dependency-check-suppression.xml
             --enableRetired
             --disableOssIndex true
 

--- a/.github/workflows/feature.yml
+++ b/.github/workflows/feature.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Build with Maven
         run: mvn package --file pom.xml
 
+      - name: TEST - filespace
+        run: pwd; ls; ls ${{github.workspace}}
+
       - name: Dependency Check
         uses: dependency-check/Dependency-Check_Action@main
         env:

--- a/.github/workflows/feature.yml
+++ b/.github/workflows/feature.yml
@@ -42,6 +42,7 @@ jobs:
             --suppress dependency-check-suppression.xml
             --enableRetired
             --disableOssIndex true
+            --disableRetireJS true
 
       - name: Upload Dependency Check Report
         if: success() || failure()

--- a/.github/workflows/feature.yml
+++ b/.github/workflows/feature.yml
@@ -28,9 +28,6 @@ jobs:
       - name: Build with Maven
         run: mvn package --file pom.xml
 
-      - name: TEST - filespace
-        run: pwd; ls; ls ${{github.workspace}}
-
       - name: Dependency Check
         uses: dependency-check/Dependency-Check_Action@main
         env:
@@ -42,7 +39,7 @@ jobs:
           format: "HTML"
           args: >
             --failOnCVSS 7.0
-            --suppress ./api/dependency-check-suppression.xml
+            --suppress dependency-check-suppression.xml
             --enableRetired
             --disableOssIndex true
 

--- a/dependency-check-suppression.xml
+++ b/dependency-check-suppression.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+    <suppress until="2023-11-09Z">
+        <notes><![CDATA[
+      Suppressing netty-transport-4.1.100.Final.jar CVE-2023-4586 as we need to wait for Netty5 to release.
+      ]]></notes>
+        <packageUrl regex="true">^pkg:maven/io\.netty/netty\-transport@.*$</packageUrl>
+        <cve>CVE-2023-4586</cve>
+    </suppress>
+
+    <suppress until="2023-11-09Z">
+        <notes><![CDATA[
+   Suppressing netty-transport-classes-epoll-4.1.100.Final.jar CVE-2023-4586 as we need to wait for Netty5 to release.
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/io\.netty/netty\-transport\-classes\-epoll@.*$</packageUrl>
+        <cve>CVE-2023-4586</cve>
+    </suppress>
+
+    <suppress until="2023-11-09Z">
+        <notes><![CDATA[
+   Suppressing netty-transport-native-unix-common-4.1.100.Final.jar CVE-2023-4586 as we need to wait for Netty5 to release.
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/io\.netty/netty\-transport\-native\-unix\-common@.*$</packageUrl>
+        <cve>CVE-2023-4586</cve>
+    </suppress>
+
+    <suppress until="2023-11-09Z">
+        <notes><![CDATA[
+   Suppressing netty-codec-4.1.100.Final.jar CVE-2023-4586 as we need to wait for Netty5 to release.
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/io\.netty/netty\-codec@.*$</packageUrl>
+        <cve>CVE-2023-4586</cve>
+    </suppress>
+
+    <suppress until="2023-11-09Z">
+        <notes><![CDATA[
+   Suppressing netty-buffer-4.1.100.Final.jar CVE-2023-4586 as we need to wait for Netty5 to release.
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/io\.netty/netty\-buffer@.*$</packageUrl>
+        <cve>CVE-2023-4586</cve>
+    </suppress>
+
+    <suppress until="2023-11-09Z">
+        <notes><![CDATA[
+   Suppressing netty-common-4.1.100.Final.jar CVE-2023-4586 as we need to wait for Netty5 to release.
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/io\.netty/netty\-common@.*$</packageUrl>
+        <cve>CVE-2023-4586</cve>
+    </suppress>
+
+    <suppress until="2023-11-09Z">
+        <notes><![CDATA[
+   Suppressing netty-handler-4.1.100.Final.jar CVE-2023-4586 as we need to wait for Netty5 to release.
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/io\.netty/netty\-handler@.*$</packageUrl>
+        <cve>CVE-2023-4586</cve>
+    </suppress>
+
+    <suppress until="2023-11-09Z">
+        <notes><![CDATA[
+   Suppressing netty-resolver-4.1.100.Final.jar CVE-2023-4586 as we need to wait for Netty5 to release.
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/io\.netty/netty\-resolver@.*$</packageUrl>
+        <cve>CVE-2023-4586</cve>
+    </suppress>
+
+    <suppress until="2023-11-09Z">
+        <notes><![CDATA[
+   Suppressing netty-codec-http-4.1.100.Final.jar CVE-2023-4586 as we need to wait for Netty5 to release.
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/io\.netty/netty\-codec\-http@.*$</packageUrl>
+        <cve>CVE-2023-4586</cve>
+    </suppress>
+
+    <suppress until="2023-11-09Z">
+        <notes><![CDATA[
+   Suppressing netty-codec-http2-4.1.100.Final.jar CVE-2023-4586 as we need to wait for Netty5 to release.
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/io\.netty/netty\-codec\-http2@.*$</packageUrl>
+        <cve>CVE-2023-4586</cve>
+    </suppress>
+</suppressions>

--- a/dependency-check-suppression.xml
+++ b/dependency-check-suppression.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
-    <suppress until="2023-11-09Z">
+    <suppress until="2023-12-01Z">
         <notes><![CDATA[
       Suppressing netty-transport-4.1.100.Final.jar CVE-2023-4586 as we need to wait for Netty5 to release.
       ]]></notes>
@@ -8,7 +8,7 @@
         <cve>CVE-2023-4586</cve>
     </suppress>
 
-    <suppress until="2023-11-09Z">
+    <suppress until="2023-12-01Z">
         <notes><![CDATA[
    Suppressing netty-transport-classes-epoll-4.1.100.Final.jar CVE-2023-4586 as we need to wait for Netty5 to release.
    ]]></notes>
@@ -16,7 +16,7 @@
         <cve>CVE-2023-4586</cve>
     </suppress>
 
-    <suppress until="2023-11-09Z">
+    <suppress until="2023-12-01Z">
         <notes><![CDATA[
    Suppressing netty-transport-native-unix-common-4.1.100.Final.jar CVE-2023-4586 as we need to wait for Netty5 to release.
    ]]></notes>
@@ -24,7 +24,7 @@
         <cve>CVE-2023-4586</cve>
     </suppress>
 
-    <suppress until="2023-11-09Z">
+    <suppress until="2023-12-01Z">
         <notes><![CDATA[
    Suppressing netty-codec-4.1.100.Final.jar CVE-2023-4586 as we need to wait for Netty5 to release.
    ]]></notes>
@@ -32,7 +32,7 @@
         <cve>CVE-2023-4586</cve>
     </suppress>
 
-    <suppress until="2023-11-09Z">
+    <suppress until="2023-12-01Z">
         <notes><![CDATA[
    Suppressing netty-buffer-4.1.100.Final.jar CVE-2023-4586 as we need to wait for Netty5 to release.
    ]]></notes>
@@ -48,7 +48,7 @@
         <cve>CVE-2023-4586</cve>
     </suppress>
 
-    <suppress until="2023-11-09Z">
+    <suppress until="2023-12-01Z">
         <notes><![CDATA[
    Suppressing netty-handler-4.1.100.Final.jar CVE-2023-4586 as we need to wait for Netty5 to release.
    ]]></notes>
@@ -56,7 +56,7 @@
         <cve>CVE-2023-4586</cve>
     </suppress>
 
-    <suppress until="2023-11-09Z">
+    <suppress until="2023-12-01Z">
         <notes><![CDATA[
    Suppressing netty-resolver-4.1.100.Final.jar CVE-2023-4586 as we need to wait for Netty5 to release.
    ]]></notes>
@@ -64,7 +64,7 @@
         <cve>CVE-2023-4586</cve>
     </suppress>
 
-    <suppress until="2023-11-09Z">
+    <suppress until="2023-12-01Z">
         <notes><![CDATA[
    Suppressing netty-codec-http-4.1.100.Final.jar CVE-2023-4586 as we need to wait for Netty5 to release.
    ]]></notes>
@@ -72,7 +72,7 @@
         <cve>CVE-2023-4586</cve>
     </suppress>
 
-    <suppress until="2023-11-09Z">
+    <suppress until="2023-12-01Z">
         <notes><![CDATA[
    Suppressing netty-codec-http2-4.1.100.Final.jar CVE-2023-4586 as we need to wait for Netty5 to release.
    ]]></notes>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 		<govuk-frontend-version>4.5.0</govuk-frontend-version>
 		<upstream.url>https://github.com/alphagov/govuk-frontend/releases/download/v${govuk-frontend-version}/release-v${govuk-frontend-version}.zip</upstream.url>
 		<destDir>${project.build.outputDirectory}/META-INF/resources/webjars/govuk-frontend/${govuk-frontend-version}</destDir>
-		<aws.java.sdk.version>2.20.45</aws.java.sdk.version>
+		<aws.java.sdk.version>2.21.5</aws.java.sdk.version>
 	</properties>
 	<dependencyManagement>
 		<dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,6 @@
 		<dependency>
 			<groupId>software.amazon.awssdk</groupId>
 			<artifactId>apigateway</artifactId>
-			<version>${aws.java.sdk.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>com.auth0</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
 		<dependency>
 			<groupId>software.amazon.awssdk</groupId>
 			<artifactId>apigateway</artifactId>
-			<version>2.21.5</version>
+			<version>${aws.java.sdk.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>com.auth0</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,7 @@
 		<dependency>
 			<groupId>software.amazon.awssdk</groupId>
 			<artifactId>apigateway</artifactId>
+			<version>2.21.5</version>
 		</dependency>
 		<dependency>
 			<groupId>com.auth0</groupId>
@@ -174,6 +175,7 @@
 				<configuration>
 					<failBuildOnCVSS>7.0</failBuildOnCVSS>
 					<ossindexAnalyzerEnabled>false</ossindexAnalyzerEnabled>
+					<suppressionFile>dependency-check-suppression.xml</suppressionFile>
 				</configuration>
 				<executions>
 					<execution>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.1.4</version>
+		<version>3.1.5</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>gov.cabinetoffice</groupId>


### PR DESCRIPTION
Updated spring boot starter parent to 3.1.5 to patch vulnerability CVE-2023-44487(7.5).