### PR TITLE
TMI2-621-fix-white-space

### DIFF
--- a/src/main/resources/templates/create-api-key-form.html
+++ b/src/main/resources/templates/create-api-key-form.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<html lang="en" class="govuk-template" xmlns:th="http://www.thymeleaf.org">
 <head>
     <meta charset="UTF-8">
     <title>Create API key</title>

--- a/src/main/resources/templates/error-page.html
+++ b/src/main/resources/templates/error-page.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<html lang="en" class="govuk-template" xmlns:th="http://www.thymeleaf.org">
 <head>
     <meta charset="UTF-8">
     <title>Something went wrong</title>

--- a/src/main/resources/templates/error.html
+++ b/src/main/resources/templates/error.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<html lang="en" class="govuk-template" xmlns:th="http://www.thymeleaf.org">
 <head>
     <meta charset="UTF-8">
     <title>Something went wrong</title>

--- a/src/main/resources/templates/fragments/footer.html
+++ b/src/main/resources/templates/fragments/footer.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html lang="en" xmlns:th="http://www.thymeleaf.org">
-    <footer class="govuk-footer" role="contentinfo" th:fragment="footer">
+    <footer class="govuk-footer footer-bottom" role="contentinfo" th:fragment="footer">
         <div class="govuk-width-container " data-cy="footer">
             <div class="govuk-footer__meta" >
                 <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">

--- a/src/main/resources/templates/new-api-key.html
+++ b/src/main/resources/templates/new-api-key.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<html lang="en" class="govuk-template" xmlns:th="http://www.thymeleaf.org">
 <head>
     <meta charset="UTF-8">
     <title>New API key</title>

--- a/src/main/resources/templates/organisation-api-keys.html
+++ b/src/main/resources/templates/organisation-api-keys.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<html lang="en" class="govuk-template" xmlns:th="http://www.thymeleaf.org">
 <head>
     <meta charset="UTF-8">
     <title>Api keys</title>

--- a/src/main/resources/templates/revoke-api-key-confirmation.html
+++ b/src/main/resources/templates/revoke-api-key-confirmation.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<html lang="en" class="govuk-template" xmlns:th="http://www.thymeleaf.org">
 <head>
     <meta charset="UTF-8">
     <title>Revoke an API key</title>

--- a/src/main/resources/templates/super-admin-api-keys.html
+++ b/src/main/resources/templates/super-admin-api-keys.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<html lang="en" class="govuk-template" xmlns:th="http://www.thymeleaf.org">
 <head>
     <meta charset="UTF-8">
     <title>Manage API keys</title>


### PR DESCRIPTION
Ticket: [TMI2-621](https://technologyprogramme.atlassian.net/browse/TMI2-621?atlOrigin=eyJpIjoiZDNmOWI1NDQ2MzhjNGEzZGE0MDg5NjBiZjFkZGFkZTEiLCJwIjoiaiJ9)

This change fixes the whitespace that appears under the footer of pages such as the manage API keys page and other pages in this repo.