### PR TITLE
Rolling spring boot version back from 3.2.2 to 3.1.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.2.2</version>
+		<version>3.1.8</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>gov.cabinetoffice</groupId>


### PR DESCRIPTION
ECS container wouldn't start using 3.2.2. Looks like the format of the target directory has changed and so the dockerfile will need additional work in order to support this version of spring and greater. 