### PR TITLE
Updates simple grant authority list logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,4 +35,5 @@ build/
 
 ### Local properties ###
 application-local.properties
+application.properties
 .env.local

--- a/src/main/java/gov/cabinetoffice/gapfindapiadmin/services/JwtService.java
+++ b/src/main/java/gov/cabinetoffice/gapfindapiadmin/services/JwtService.java
@@ -16,10 +16,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
 import java.util.List;
-
-import static gov.cabinetoffice.gapfindapiadmin.security.JwtAuthorisationFilter.ADMIN_ROLE;
-import static gov.cabinetoffice.gapfindapiadmin.security.JwtAuthorisationFilter.SUPER_ADMIN_ROLE;
-import static gov.cabinetoffice.gapfindapiadmin.security.JwtAuthorisationFilter.TECHNICAL_SUPPORT_ROLE;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @Service
@@ -60,23 +58,12 @@ public class JwtService {
                 .aud(aud).exp(exp).iat(iat).build();
     }
 
-    public List<SimpleGrantedAuthority> generateSimpleGrantedAuthorityList(boolean isSuperAdmin, boolean isAdmin) {
-        List<SimpleGrantedAuthority> simpleGrantedAuthorityList;
+    public List<SimpleGrantedAuthority> generateSimpleGrantedAuthorityList(Map<String, Boolean> roles) {
 
-        if (isSuperAdmin) {
-            simpleGrantedAuthorityList = List.of(new SimpleGrantedAuthority(SUPER_ADMIN_ROLE),
-                    new SimpleGrantedAuthority(ADMIN_ROLE),
-                    new SimpleGrantedAuthority(TECHNICAL_SUPPORT_ROLE));
-        } else if (isAdmin) {
-            simpleGrantedAuthorityList = List.of(
-                    new SimpleGrantedAuthority(ADMIN_ROLE),
-                    new SimpleGrantedAuthority(TECHNICAL_SUPPORT_ROLE)
-            );
-        } else {
-            simpleGrantedAuthorityList = List.of(new SimpleGrantedAuthority(TECHNICAL_SUPPORT_ROLE));
-        }
-
-        return simpleGrantedAuthorityList;
+        return roles.entrySet().stream()
+                .filter(Map.Entry::getValue)
+                .map(entry -> new SimpleGrantedAuthority(entry.getKey()))
+                .collect(Collectors.toList());
     }
 
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,6 @@
 spring.datasource.url=jdbc:postgresql://localhost:5432/gapapply
 spring.datasource.username=postgres
-spring.datasource.password=postgres
+spring.datasource.password=mysecretpassword
 spring.datasource.hikari.maximumPoolSize=5
 
 server.port=8086
@@ -23,9 +23,8 @@ aws.secretKey=secretKey
 aws.accessKeyId=accessKey
 aws.region=eu-west-2
 
-# QA
-aws.apiGatewayId=0qgqswv4ai
-aws.apiGatewayUsagePlanId=eqp3ws
+aws.apiGatewayId=apiGatewayId
+aws.apiGatewayUsagePlanId=apiGatewayUsagePlanId
 
 navbar.superAdminDashboardLink=http://localhost:3000/apply/admin/super-admin-dashboard
 navbar.adminDashboardLink=http://localhost:3000/apply/admin/dashboard

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,6 @@
 spring.datasource.url=jdbc:postgresql://localhost:5432/gapapply
 spring.datasource.username=postgres
-spring.datasource.password=mysecretpassword
+spring.datasource.password=postgres
 spring.datasource.hikari.maximumPoolSize=5
 
 server.port=8086
@@ -23,8 +23,9 @@ aws.secretKey=secretKey
 aws.accessKeyId=accessKey
 aws.region=eu-west-2
 
-aws.apiGatewayId=apiGatewayId
-aws.apiGatewayUsagePlanId=apiGatewayUsagePlanId
+# QA
+aws.apiGatewayId=0qgqswv4ai
+aws.apiGatewayUsagePlanId=eqp3ws
 
 navbar.superAdminDashboardLink=http://localhost:3000/apply/admin/super-admin-dashboard
 navbar.adminDashboardLink=http://localhost:3000/apply/admin/dashboard

--- a/src/test/java/gov/cabinetoffice/gapfindapiadmin/services/JwtServiceTest.java
+++ b/src/test/java/gov/cabinetoffice/gapfindapiadmin/services/JwtServiceTest.java
@@ -6,6 +6,7 @@ import com.auth0.jwt.interfaces.DecodedJWT;
 import gov.cabinetoffice.gapfindapiadmin.config.UserServiceConfig;
 import gov.cabinetoffice.gapfindapiadmin.exceptions.UnauthorizedException;
 import gov.cabinetoffice.gapfindapiadmin.models.JwtPayload;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -23,13 +24,9 @@ import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.NoSuchAlgorithmException;
 import java.security.interfaces.RSAPrivateKey;
-import java.util.Calendar;
-import java.util.Date;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 
-import static gov.cabinetoffice.gapfindapiadmin.security.JwtAuthorisationFilter.SUPER_ADMIN_ROLE;
-import static gov.cabinetoffice.gapfindapiadmin.security.JwtAuthorisationFilter.TECHNICAL_SUPPORT_ROLE;
+import static gov.cabinetoffice.gapfindapiadmin.security.JwtAuthorisationFilter.*;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.mockito.Mockito.*;
@@ -115,27 +112,51 @@ class JwtServiceTest {
 
     @Nested
     class generateSimpleGrantedAuthorityList{
+
         @Test
         void testGenerateSimpleGrantedAuthorityListSuperAdmin() {
-            final List<SimpleGrantedAuthority> result = jwtService.generateSimpleGrantedAuthorityList(true, false);
+            Map<String, Boolean> rolesMap = Map.of(SUPER_ADMIN_ROLE, true,
+                    ADMIN_ROLE, false, TECHNICAL_SUPPORT_ROLE, false);
+            final List<SimpleGrantedAuthority> result = jwtService.generateSimpleGrantedAuthorityList(rolesMap);
 
-            assertThat(result.size()).isEqualTo(3 );
+            assertThat(result.size()).isEqualTo(1 );
             assertThat(result.get(0).getAuthority()).isEqualTo(SUPER_ADMIN_ROLE);
         }
 
         @Test
         void testGenerateSimpleGrantedAuthorityListAdmin() {
-            final List<SimpleGrantedAuthority> expected = List.of(new SimpleGrantedAuthority("ADMIN"), new SimpleGrantedAuthority(TECHNICAL_SUPPORT_ROLE));
+            Map<String, Boolean> rolesMap = Map.of(SUPER_ADMIN_ROLE, false,
+                    ADMIN_ROLE, true, TECHNICAL_SUPPORT_ROLE, true);
 
-            List<SimpleGrantedAuthority> result = jwtService.generateSimpleGrantedAuthorityList(false, true);
+            final List<SimpleGrantedAuthority> expected = List.of(
+                    new SimpleGrantedAuthority(TECHNICAL_SUPPORT_ROLE), new SimpleGrantedAuthority(ADMIN_ROLE));
+
+            List<SimpleGrantedAuthority> result = jwtService.generateSimpleGrantedAuthorityList(rolesMap);
 
             assertThat(result.size()).isEqualTo(2);
-            assertThat(result).isEqualTo(expected);
+            Assertions.assertTrue(result.containsAll(expected));
+        }
+
+        @Test
+        void testGenerateSimpleGrantedAuthorityListAllRoles() {
+            Map<String, Boolean> rolesMap = Map.of(SUPER_ADMIN_ROLE, true,
+                    ADMIN_ROLE, true, TECHNICAL_SUPPORT_ROLE, true);
+
+            final List<SimpleGrantedAuthority> expected = List.of(
+                    new SimpleGrantedAuthority(SUPER_ADMIN_ROLE),
+                    new SimpleGrantedAuthority(TECHNICAL_SUPPORT_ROLE), new SimpleGrantedAuthority(ADMIN_ROLE));
+
+            List<SimpleGrantedAuthority> result = jwtService.generateSimpleGrantedAuthorityList(rolesMap);
+
+            assertThat(result.size()).isEqualTo(3);
+            Assertions.assertTrue(result.containsAll(expected));
         }
 
         @Test
         void testGenerateSimpleGrantedAuthorityListTechnicalSupport() {
-            final List<SimpleGrantedAuthority> result = jwtService.generateSimpleGrantedAuthorityList(false, false);
+            Map<String, Boolean> rolesMap = Map.of(SUPER_ADMIN_ROLE, false,
+                    ADMIN_ROLE, false, TECHNICAL_SUPPORT_ROLE, true);
+            final List<SimpleGrantedAuthority> result = jwtService.generateSimpleGrantedAuthorityList(rolesMap);
 
             assertThat(result.size()).isEqualTo(1);
             assertThat(result.get(0).getAuthority()).isEqualTo(TECHNICAL_SUPPORT_ROLE);


### PR DESCRIPTION
Changes as part of this PR:

- checks for tech support user role explicitly 
- updates code to generate simple grant authority list
      - This now takes a roles map and adds them to simple grant authority list
- Updates unit tests

This will enable super admins to access the api keys (/api-keys) page if they have tech support user role
(note if SA does not have the tech support role they should still be able to access manage api keys page (/api-keys/manage)

Other PRs included in this change:

https://github.com/cabinetoffice/gap-find-admin-backend/pull/180
https://github.com/cabinetoffice/gap-find-apply-web/pull/311