### PR TITLE
TMI2-619: allow space in api key name

### DIFF
--- a/src/main/java/gov/cabinetoffice/gapfindapiadmin/dtos/CreateApiKeyDTO.java
+++ b/src/main/java/gov/cabinetoffice/gapfindapiadmin/dtos/CreateApiKeyDTO.java
@@ -17,8 +17,10 @@ import lombok.NoArgsConstructor;
 public class CreateApiKeyDTO {
 
 	@NotBlank(message = "Enter a key name")
-	@Pattern(regexp = "^[a-zA-Z0-9]*$", message = "Key name must be alphanumeric")
-	@Size(max = 1024, message = "Key name must be max 1024 characters") // TODO check what to set max length to, it's 50 in DB
+	@Pattern(regexp = "^(?!\\s).*", message = "Key name must not start with empty spaces")
+	@Pattern(regexp = "^[a-zA-Z0-9\\s]*$", message = "Key name must be alphanumeric")
+	@Pattern(regexp = "^(?!\\s)(.*\\S)?$", message = "Key name  must not end with a space")
+	@Size(max = 1024, message = "Key name must be max 1024 characters")
 	private String keyName;
 
 }


### PR DESCRIPTION
add regex validation for allowing space only between words(withouth sonarlint complaining on pox Stack over flow exceptions)